### PR TITLE
Cleanup setup dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ python:
   - "3.6"
 
 install:
-  - make install
+  - make setup
   - pip install coveralls
 
 script:

--- a/Makefile
+++ b/Makefile
@@ -40,13 +40,13 @@ clean-build:
 	rm -rf *.egg-info
 
 setup: clean
-	python setup.py develop
+	pip install -U -e .[dev,test]
 
 setup-dev: clean
 	virtualenv -p python3 venv
 	./venv/bin/pip install -U pip
-	./venv/bin/pip install -U setuptools twine bumpversion
-	./venv/bin/python setup.py develop
+	./venv/bin/pip install -U setuptools
+	./venv/bin/pip install -U -e .[dev,test]
 
 install: clean
 	python setup.py install
@@ -66,7 +66,6 @@ lint:
 tests:
 	@echo ">>> running tests"
 	python tests/run.py || ( echo ">>> tests failed"; exit 1; )
-#	python setup.py test
 
 release-check: type-check flake8-check lint tests
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from os.path import exists
 from setuptools import find_packages, setup
 from setuptools.dist import Distribution
 
-import ftoolz
+from ftoolz import __version__ as ftoolz_version
 
 
 class BinaryDistribution(Distribution):
@@ -15,6 +15,15 @@ class BinaryDistribution(Distribution):
         return True
 
 
+ftoolz_requirements = [
+    'cytoolz==0.9.0.1',
+]
+
+dev_requirements = [
+    'bumpversion==0.5.3',
+    'twine==1.13.0',
+]
+
 test_requirements = [
     # 'astroid==2.2.5',
     'astroid==2.1.0',
@@ -23,8 +32,6 @@ test_requirements = [
     # 'mypy==0.700',
     'mypy==0.630',
     'nose==1.3.7',
-    # 'nose2==0.8.0',
-    # 'nose2[coverage_plugin]>=0.6.5',
     # 'pylint==2.3.0',
     'pylint==2.2.0',
     'typed-ast==1.1.1',
@@ -32,10 +39,10 @@ test_requirements = [
 
 setup(
     name='ftoolz',
-    version=ftoolz.__version__,
+    version=ftoolz_version,
     description='Collection of higher-order and utility functions',
     long_description=(open('README.md').read() if exists('README.md') else ''),
-    long_description_content_type="text/markdown",
+    long_description_content_type='text/markdown',
     classifiers=[
         'Development Status :: 4 - Beta',
         'Environment :: Console',
@@ -56,7 +63,8 @@ setup(
     distclass=BinaryDistribution,
     zip_safe=False,
     python_requires='>=3.6',
-    install_requires=['cytoolz==0.9.0.1'] + test_requirements,
+    install_requires=ftoolz_requirements,
+    extras_require={'dev': dev_requirements, 'test': test_requirements},
     test_suite='tests',
-    tests_require=test_requirements,
+    tests_require=ftoolz_requirements + test_requirements,
 )


### PR DESCRIPTION
### Description
* Removes test requirements from installation
* Moves `twine` and `bumpversion` to `setup.py` as extra dev requirements

### Test plan
* Tested `make setup-dev` and `make build` locally
* Tested upload to test PyPI and `pip install` from there (installs just cytoolz, but fails because it's not on test PyPI)
* Checked `make release-check`