### PR TITLE
Upgrade pylint and mypy

### DIFF
--- a/ftoolz/functoolz/seq.py
+++ b/ftoolz/functoolz/seq.py
@@ -4,7 +4,7 @@ from typing import Any, Callable, Tuple
 from cytoolz.itertoolz import identity, mapcat
 
 from ftoolz.functoolz import A, A_in, A_out, B, B_in, B_out, C_out
-from ftoolz.typing import Seq
+from ftoolz.typing import Seq, seq
 
 
 def apply(ff: Seq[Callable[[A_in], B_out]], fa: Seq[A_in]) -> Seq[B_out]:
@@ -49,7 +49,7 @@ def flatmap(f: Callable[[A_in], Seq[B_out]], fa: Seq[A_in]) -> Seq[B_out]:
     >>> flatmap(f, (1, 2, 3))
     ('1', '1', '2', '2', '3', '3')
     """
-    return tuple(mapcat(f, fa))
+    return seq(mapcat(f, fa))
 
 
 def flatten(ffa: Seq[Seq[A]]) -> Seq[A]:
@@ -109,7 +109,7 @@ def fmap2(
     def ff(a: A_in) -> Seq[C_out]:
         return fmap(lambda b: f(a, b), fb)
 
-    return tuple() if not fb else flatmap(ff, fa)
+    return seq() if not fb else flatmap(ff, fa)
 
 
 def fproduct(f: Callable[[A], B_out], fa: Seq[A]) -> Seq[Tuple[A, B_out]]:
@@ -168,7 +168,7 @@ def generate(
         step = args[2] if len(args) > 2 else kwargs.get('step', 1)
         series = range(start, stop, step)
 
-    return tuple(f(i) for i in series)
+    return seq(f(i) for i in series)
 
 
 def lift(f: Callable[[A_in], B_out]) -> Callable[[Seq[A_in]], Seq[B_out]]:
@@ -244,4 +244,4 @@ def zip_map(f: Callable[..., A_out], *fx: Seq[Any]) -> Seq[A_out]:
     >>> zip_map(f, (1, 2, 3, 4), ('a', 'b', 'c'))
     ('a', 'bb', 'ccc')
     """
-    return tuple(starmap(f, zip(*fx)))
+    return seq(starmap(f, zip(*fx)))

--- a/ftoolz/functoolz/traverse/opt.py
+++ b/ftoolz/functoolz/traverse/opt.py
@@ -5,7 +5,7 @@ from cytoolz.itertoolz import cons, identity
 from ftoolz.functoolz import A, A_in, B
 from ftoolz.functoolz.opt import fmap, fmap2
 from ftoolz.itertoolz import fold_right
-from ftoolz.typing import Seq
+from ftoolz.typing import Seq, seq
 
 
 def sequence_iter(gfa: Iterable[Optional[A]]) -> Optional[Iterable[A]]:
@@ -54,12 +54,12 @@ def sequence_seq(gfa: Seq[Optional[A]]) -> Optional[Seq[A]]:
     >>> sequence_seq(tuple())
     ()
     """
-    return fmap(tuple, traverse_iter(identity, gfa))
+    return fmap(seq, traverse_iter(identity, gfa))
 
 
 def traverse_iter(
         f: Callable[[A_in], Optional[B]],
-        seq: Iterable[A_in]
+        fa: Iterable[A_in]
 ) -> Optional[Iterable[B]]:
     """
     Given a function which returns a `Optional` effect, thread this effect
@@ -71,12 +71,10 @@ def traverse_iter(
     """
 
     def op(a: A_in, acc: Optional[Iterable[B]]) -> Optional[Iterable[B]]:
-        # FIXME: mypy cannot resolve correct type event though it's fine
-        op_res: Optional[Iterable[B]] = fmap2(cons, f(a), acc)
-        return op_res
+        return fmap2(cons, f(a), acc)  # type: ignore
 
     empty: Optional[Iterable[B]] = iter([])
-    return fold_right(op, seq, empty)
+    return fold_right(op, fa, empty)
 
 
 def traverse_seq(
@@ -99,4 +97,4 @@ def traverse_seq(
     >>> traverse_seq(f, tuple())
     ()
     """
-    return fmap(tuple, traverse_iter(f, fa))
+    return fmap(seq, traverse_iter(f, fa))  # type: ignore

--- a/ftoolz/typing.py
+++ b/ftoolz/typing.py
@@ -1,4 +1,4 @@
-from typing import Mapping, Optional, Sequence, TypeVar
+from typing import Iterable, Mapping, Optional, Sequence, TypeVar
 
 A = TypeVar('A')
 B = TypeVar('B')
@@ -25,3 +25,25 @@ def assert_some(a: Optional[A]) -> A:
     if a is None:
         raise TypingError('Item expected to be not None, None given.')
     return a
+
+
+def seq(it: Optional[Iterable[A]] = None) -> Seq[A]:
+    """
+    Type constructor for immutable :class:`Seq`.
+
+    >>> it = iter([1, 2, 3])
+    >>> seq(it)
+    (1, 2, 3)
+
+    Constructor is terminal in provided :class:`Iterable`.
+    >>> next(it)
+    Traceback (most recent call last):
+    ...
+    StopIteration
+
+    >>> seq(iter([]))
+    ()
+    >>> seq()
+    ()
+    """
+    return tuple(it) if it is not None else tuple()

--- a/ftoolz/typing.py
+++ b/ftoolz/typing.py
@@ -27,7 +27,7 @@ def assert_some(a: Optional[A]) -> A:
     return a
 
 
-def seq(it: Optional[Iterable[A]] = None) -> Seq[A]:
+def seq(it: Iterable[A] = ()) -> Seq[A]:
     """
     Type constructor for immutable :class:`Seq`.
 
@@ -46,4 +46,4 @@ def seq(it: Optional[Iterable[A]] = None) -> Seq[A]:
     >>> seq()
     ()
     """
-    return tuple(it) if it is not None else tuple()
+    return tuple(it)

--- a/setup.py
+++ b/setup.py
@@ -25,16 +25,11 @@ dev_requirements = [
 ]
 
 test_requirements = [
-    # 'astroid==2.2.5',
-    'astroid==2.1.0',
     'coverage==4.5.1',
     'flake8==3.7.7',
-    # 'mypy==0.700',
-    'mypy==0.630',
+    'mypy==0.701',
     'nose==1.3.7',
-    # 'pylint==2.3.0',
-    'pylint==2.2.0',
-    'typed-ast==1.1.1',
+    'pylint==2.3.1',
 ]
 
 setup(


### PR DESCRIPTION
### Description
* Upgrades mypy and pylint to latest versions (up to this date and PyPI)
* Removes `astroid` and `typed-ast` dependencies as these are not needed for new mypy and pylint versions
* Adds `seq` type constructor for class `Seq`, usage of which fixes typing for `sequence_seq`
* Adds `type: ignore` to `traverse` functions where mypy can't resolve correct generics

### Test plan
* Tested creating new dev environment with `make setup-dev`
* Passing release check