### PR TITLE
Itertoolz: ordering-related functions and ADT package

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -30,7 +30,7 @@ method-rgx=[a-z_][a-z0-9_]{2,60}$
 # defaults were i,j,k,ex,Run,_
 good-names=
     a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t,u,v,w,x,y,z,A,B,C,D,E,F,G,K,R,T,R,V,Z,
-    ex,fa,fb,fc,ff,fn,id,it,op,xs,ys,zs,_,,applyN,fmap,fmapN,
+    by,ex,fa,fb,fc,ff,fn,id,it,op,xs,ys,zs,_,,applyN,fmap,fmapN,
     A_in,B_in,C_in,D_in,A_out,A_out,B_out,C_out,D_out
 
 const-naming-style=any

--- a/README.md
+++ b/README.md
@@ -6,6 +6,13 @@ Collection of higher-order and utility functions built on top of `cytoolz`.
 ## Module overview
 Ftoolz are split into few generic modules.
 
+### adt package
+Package that provides implementation for various Abstract Data Types (ADTs).
+
+| ADT | Description |
+|----------|-------------|
+| `MutIter(s0)` | mutable iterator that can be both consumed and appended to, optionally initialized with init state `s0` |
+
 ### functoolz package
 Package that provides higher-order functions commonly associated with Functor, Applicative and Monad. 
 
@@ -112,6 +119,8 @@ selected by `key_fn` |
 | `iter_with_final(iterable)` | creates iterable of tuples of original element and final flag |
 | `last(sequence)` | return last element of a sequence or `None` |
 | `make_str(iterable, key_fn, separator)` | create string of tokens from iterable selected by `key_fn` with separator |
+| `order_by(iterable, by, key_fn)` | order `iterable` w.r.t. order given by keys sequence `by` (given key-getter `key_fn`) and fill in missing values as `None` |
+| `positions(sequence)` | collect positions of non-unique items in original sequence |
 | `split_by(predicate, iterable)` | split elements of iterable by predicate to positives and negatives |
 | `take(n, iterable)` | take first n elements of an iterable |
 | `take_first(iterable)` | take first element of an iterable or fail |

--- a/ftoolz/adt/mutiter.py
+++ b/ftoolz/adt/mutiter.py
@@ -1,0 +1,132 @@
+from collections import deque
+from typing import Deque, Iterable, Iterator, Optional, Sized, TypeVar
+
+from ftoolz.typing import Seq
+
+_E = TypeVar('_E')
+
+
+class MutIter(Iterator[_E], Sized):
+    """
+    Mutable iterator that can be both appended and consumend. Example usage is
+    as an accumulator for `reduceby`.
+
+    This implementation holds all data in memory. This means that the
+    :class:`Iterable` of an initial state is fully consumed.
+
+    **Warn**: This implementation is **not** thread-safe.
+
+    Example behavior:
+
+    >>> it = MutIter([1, 2])
+    >>> print(it)
+    MutIter(1, 2)
+
+    >>> it += 3
+    >>> print(it)
+    MutIter(1, 2, 3)
+
+    >>> it.state()
+    (1, 2, 3)
+
+    >>> next(it), next(it), next(it)
+    (1, 2, 3)
+    >>> next(it, -1)
+    -1
+
+    >>> MutIter.add(it, 42)
+    MutIter(state=deque([42]))
+    """
+
+    def __init__(self, state: Optional[Iterable[_E]] = None) -> None:
+        """
+        >>> MutIter()
+        MutIter(state=deque([]))
+        >>> MutIter([1, 2, 3])
+        MutIter(state=deque([1, 2, 3]))
+        """
+        self._state: Deque[_E] = deque(state) if state is not None else deque()
+
+    @staticmethod
+    def add(it: 'MutIter', e: _E) -> 'MutIter':
+        """
+        Binop which adds `e` to `it` state and returns modified state.
+
+        >>> MutIter.add(MutIter([1, 2]), 3)
+        MutIter(state=deque([1, 2, 3]))
+        >>> MutIter.add(MutIter([]), 42)
+        MutIter(state=deque([42]))
+        """
+        it += e
+        return it
+
+    def state(self) -> Seq[_E]:
+        """
+        Get immutable copy of current state.
+
+        >>> MutIter([1, 2, 3]).state()
+        (1, 2, 3)
+        >>> MutIter().state()
+        ()
+        """
+        return tuple(self._state)
+
+    def __iadd__(self, other: _E) -> 'MutIter':
+        """
+        >>> it = MutIter()
+        >>> it += 4
+        >>> it += 2
+        >>> it
+        MutIter(state=deque([4, 2]))
+        """
+        self._state.append(other)
+        return self
+
+    def __iter__(self) -> 'MutIter':
+        """
+        >>> it = MutIter()
+        >>> it is iter(it)
+        True
+        """
+        return self
+
+    def __next__(self) -> _E:
+        """
+        >>> next(MutIter())
+        Traceback (most recent call last):
+        ...
+        StopIteration
+        >>> next(MutIter(), None)
+        >>> it = MutIter([1, 2, 3])
+        >>> next(it)
+        1
+        >>> it
+        MutIter(state=deque([2, 3]))
+        """
+        if not self._state:
+            raise StopIteration
+        return self._state.popleft()
+
+    def __len__(self) -> int:
+        """
+        >>> len(MutIter([]))
+        0
+        >>> len(MutIter([1, 2, 3]))
+        3
+        """
+        return len(self._state)
+
+    def __bool__(self) -> bool:
+        """
+        >>> bool(MutIter())
+        False
+        >>> bool(MutIter([1, 2, 3]))
+        True
+        """
+        return bool(self._state)
+
+    def __repr__(self) -> str:
+        return f'MutIter(state={repr(self._state)})'
+
+    def __str__(self) -> str:
+        return f'MutIter{self.state()}'

--- a/ftoolz/adt/mutiter.py
+++ b/ftoolz/adt/mutiter.py
@@ -45,6 +45,7 @@ class MutIter(Iterator[_E], Sized):
         >>> MutIter([1, 2, 3])
         MutIter(state=deque([1, 2, 3]))
         """
+        super().__init__()
         self._state: Deque[_E] = deque(state) if state is not None else deque()
 
     @staticmethod

--- a/ftoolz/adt/mutiter.py
+++ b/ftoolz/adt/mutiter.py
@@ -6,7 +6,7 @@ from ftoolz.typing import Seq
 _E = TypeVar('_E')
 
 
-class MutIter(Iterator[_E], Sized):
+class MutIter(Iterator[_E], Sized):  # pylint: disable=E0239
     """
     Mutable iterator that can be both appended and consumend. Example usage is
     as an accumulator for `reduceby`.


### PR DESCRIPTION
### Description
* Adds new package `adt` for Abstract Data Types (ADTs)
  * implements mutable iterator `MutIter` which can be both consumed and appended to
  * example usage: as an accumulator for `reduceby` and similar
* Adds two new functions to `itertoolz`
  * `positions` - collects positions of non-unique items in a sequence
  * `order_by` - orders (and fills missing) items in order given by a sequence of keys

### Test plan
Passing release check and complete coverage.